### PR TITLE
added ext-* requirements to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,11 @@
 {
     "name": "d11wtq/boris",
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "ext-readline": "*",
+        "ext-pcntl": "*",
+        "ext-posix": "*",
+        "ext-sockets": "*"
     },
     "autoload": {
         "psr-0": {"Boris": "lib"}


### PR DESCRIPTION
Added requirements for readline, pcntl, posix and sockets extensions to composer.json, so users won't complain about smth not working after installing Boris
