### PR TITLE
Error reporting level

### DIFF
--- a/bin/boris
+++ b/bin/boris
@@ -6,4 +6,5 @@
 require_once __DIR__.'/../lib/autoload.php';
 
 $boris = new \Boris\Boris();
+$boris->setErrorReporting(0);
 $boris->start();

--- a/lib/Boris/Boris.php
+++ b/lib/Boris/Boris.php
@@ -57,6 +57,15 @@ class Boris {
     $this->_inspector = $inspector;
   }
 
+    /**
+     * Set the error reporting level
+     *
+     * @param int $errorLevel the level of error to report
+     */
+    public function setErrorReporting($errorLevel) {
+       error_reporting($errorLevel);
+   }
+
   /**
    * Start the REPL (display the readline prompt).
    *


### PR DESCRIPTION
For those of us who have error display turned on and error reporting level set to all errors - we might get unwanted notices and warnings on the cli. 

With this patch, it'd be possible to set the error level. 
