### PR TITLE
s/include_one/include_once (typo in ShallowParser)

### DIFF
--- a/lib/Boris/ShallowParser.php
+++ b/lib/Boris/ShallowParser.php
@@ -202,7 +202,7 @@ class ShallowParser {
     $input = trim($input);
     return substr($input, -1) == ';' && !preg_match(
       '/^(' .
-      'echo|print|exit|die|goto|global|include|include_one|require|require_once|list|' .
+      'echo|print|exit|die|goto|global|include|include_once|require|require_once|list|' .
       'return|do|for|while|if|function|namespace|class|interface|abstract|switch|' .
       'declare|throw|try|unset' .
       ')\b/i',


### PR DESCRIPTION
Title pretty much says it all. Small typo in `ShallowParser` that may cause trouble with `include_once`.

Cheers!
