### PR TITLE
Workaround stream_select issues. Closes #26

### DIFF
--- a/lib/Boris/EvalWorker.php
+++ b/lib/Boris/EvalWorker.php
@@ -202,7 +202,13 @@ class EvalWorker {
     $write = null;
     $except = array($socket);
 
-    if (stream_select($read, $write, $except, 10) > 0) {
+
+    $n = @stream_select($read, $write, $except, 10);
+    if ($n === false) {
+      return null;
+    }
+
+    if ($n > 0) {
       if ($read) {
         return stream_get_contents($read[0]);
       } else if ($except) {


### PR DESCRIPTION
Note that because of the `continue` on `line 91`, the input for the current line continues to be empty until at least 1 more enter and then a statement that returns a value. If `^C` is pressed several times in a row, the line will continue to build up to no known effect.
