### PR TITLE
Add support for --version option

### DIFF
--- a/bin/boris
+++ b/bin/boris
@@ -3,8 +3,6 @@
 
 /* vim: set shiftwidth=2 expandtab softtabstop=2: */
 
-define( 'BORIS_VERSION', '1.0.2-alpha' );
-
 require_once __DIR__.'/../lib/autoload.php';
 
 $boris  = new \Boris\Boris();

--- a/lib/Boris/Boris.php
+++ b/lib/Boris/Boris.php
@@ -2,16 +2,14 @@
 
 /* vim: set shiftwidth=2 expandtab softtabstop=2: */
 
-/**
- * @version 1.0.1
- */
-
 namespace Boris;
 
 /**
  * Boris is a tiny REPL for PHP.
  */
 class Boris {
+  const VERSION = "1.0.1";
+
   private $_prompt;
   private $_historyFile;
   private $_exports = array();

--- a/lib/Boris/CLIOptionsHandler.php
+++ b/lib/Boris/CLIOptionsHandler.php
@@ -79,7 +79,7 @@ USAGE;
   }
 
   private function _handleVersion() {
-    printf("Boris %s\n", BORIS_VERSION);
+    printf("Boris %s\n", Boris::VERSION);
     exit(0);
   }
 }


### PR DESCRIPTION
All the cool REPLs have it: `python --version`, `irb --version`, `go version` etc.

But seriously, it's just handy sometimes.
