### PR TITLE
Added foreach to the list of non-returnable keywords.

### DIFF
--- a/lib/Boris/ShallowParser.php
+++ b/lib/Boris/ShallowParser.php
@@ -203,7 +203,7 @@ class ShallowParser {
     return substr($input, -1) == ';' && !preg_match(
       '/^(' .
       'echo|print|exit|die|goto|global|include|include_once|require|require_once|list|' .
-      'return|do|for|while|if|function|namespace|class|interface|abstract|switch|' .
+      'return|do|for|foreach|while|if|function|namespace|class|interface|abstract|switch|' .
       'declare|throw|try|unset' .
       ')\b/i',
       $input


### PR DESCRIPTION
Previously running:

``` php
foreach([1,2,3,4] as $a) echo $a;
```

gives:

```
 PHP Parse error:  syntax error, unexpected 'foreach' (T_FOREACH) EvalWorker.php(122) : eval()'d  code on line 1
```

now:

```
1234
```
