### PR TITLE
Remove PHP extension dependencies from composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,11 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "suggest": {
+        "ext-readline": "*",
+        "ext-pcntl": "*",
+        "ext-posix": "*"
+    },
     "autoload": {
         "psr-0": {"Boris": "lib"}
     },


### PR DESCRIPTION
While having these dependencies makes sense when using Boris stand-alone. It causes problems when Boris is integrated into a larger project where it is a single, optional piece, such as the Laravel framework, which I maintain.

With these restrictions, Composer won't let me install Boris at all. My goal is for people on Mac / Unix to be able to run it and to fall back to a much simpler Laravel command-line on Windows or if the extensions are not available.

Would it be possible to simply remove these restrictions so that Composer will actually let me install the package and integrate it into Laravel?
