### PR TITLE
Follow redirects in example curl usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Boris is available for download as a Phar archive:
 
 Simply download it and run it.
 
-    curl -O https://github.com/d11wtq/boris/releases/download/v1.0.8/boris.phar
+    curl -L -O https://github.com/d11wtq/boris/releases/download/v1.0.8/boris.phar
     chmod +x boris.phar
     ./boris.phar
 


### PR DESCRIPTION
Modify curl installation instructions to automatically follow redirects. Otherwise you might end up downloading HTML from GitHub.
