### PR TITLE
full support for use stmts via new macro system

### DIFF
--- a/lib/Boris/Boris.php
+++ b/lib/Boris/Boris.php
@@ -16,6 +16,7 @@ class Boris {
   private $_startHooks = array();
   private $_failureHooks = array();
   private $_inspector;
+  private $_macros = array();
 
   /**
    * Create a new REPL, which consists of an evaluation worker and a readline client.
@@ -132,6 +133,16 @@ class Boris {
   }
 
   /**
+   * Set an Macro pattern for Boris to transform input expressions.
+   *
+   * @param string $match A regex pattern to compare against input expressions.
+   * @param string|callable $replacer A replacer string or callback function.
+   */
+  public function setMacro($match, $replacer) {
+    $this->_macros[$match] = $replacer;
+  }
+
+  /**
    * Start the REPL (display the readline prompt).
    *
    * This method never returns.
@@ -168,6 +179,7 @@ class Boris {
       $worker->setStartHooks($this->_startHooks);
       $worker->setFailureHooks($this->_failureHooks);
       $worker->setInspector($this->_inspector);
+      $worker->addMacros($this->_macros);
       $worker->start();
     }
   }

--- a/lib/Boris/ShallowParser.php
+++ b/lib/Boris/ShallowParser.php
@@ -214,7 +214,7 @@ class ShallowParser {
         '/^(' .
         'echo|print|exit|die|goto|global|include|include_once|require|require_once|list|' .
         'return|do|for|foreach|while|if|function|namespace|class|interface|abstract|switch|' .
-        'declare|throw|try|unset' .
+        'declare|throw|try|unset|use' .
         ')\b/i',
         $input
       );


### PR DESCRIPTION
Created as an alternative and as a reply to https://github.com/d11wtq/boris/pull/72

User supplied macros:

A new Boris::setMacro(), provides a hook that users can leverage in .borisrc/etc to supply match/replace code to be called in EvalWorker::_transform().  Similar to the 'exit' => 'exit(0)' transform that existed (but did nothing in my tests), macros are defined as a mapping of a regex pattern to a replacement string or a callback, suitable for preg_replace/preg_replace_callback, respectively.

I then added full support for "use" stmts by creating a builtin macro, that transform a use stmt into one or more calls to class_alias() (one for each alias).  However, my initBuiltinMacros()/addUseMacro() organization/approach feels lacking, and like it should be moved elsewhere.

Finally, I added "use" to the list of keywords that are not "returnable" (not needing a "return " prefix).

Cheers, and thank you for boris!