### PR TITLE
Adds specifics on how to use globally installed with composer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Simply download it and run it.
 For use with composer.
 
   - https://packagist.org/packages/d11wtq/boris
+  
+Can be installed globally via:
+  
+    composer global require 'd11wtq/boris=1.0.*'
+    ~/.composer/vendor/bin/boris
 
 ### 3. Directly from this repo
 


### PR DESCRIPTION
Moreover, adding ~/.composer/vendor/bin/ to your $PATH allows it to be called from the command line as simply:
```bash
boris
```

I wasn't sure if that was worth noting though.