### PR TITLE
Allow function and const import in the current namespace using `use`

### DIFF
--- a/lib/Boris/ShallowParser.php
+++ b/lib/Boris/ShallowParser.php
@@ -217,7 +217,17 @@ class ShallowParser
     
     private function _scanUse($result)
     {
-        if (preg_match("/^use (.+?);/", $result->buffer, $use)) {
+        if (preg_match("/^use function (.+?);/", $result->buffer, $use)) {
+            $result->buffer = substr($result->buffer, strlen($use[0]));
+            if (strpos($use[0], ' as ') !== false) {
+                list($function, $alias) = explode(' as ', $use[1]);
+            } else {
+                $function = $use[1];
+                $alias = substr($use[1], strrpos($use[1], '\\') + 1);
+            }
+            $result->statements[] = sprintf("function %s() { return call_user_func_array('%s', func_get_args()); };", $alias, $function);
+            return true;
+        } else if (preg_match("/^use (.+?);/", $result->buffer, $use)) {
             $result->buffer = substr($result->buffer, strlen($use[0]));
             if (strpos($use[0], ' as ') !== false) {
                 list($class, $alias) = explode(' as ', $use[1]);

--- a/lib/Boris/ShallowParser.php
+++ b/lib/Boris/ShallowParser.php
@@ -214,28 +214,28 @@ class ShallowParser
         
         return true;
     }
-    
+
     private function _scanUse($result)
     {
-        if (preg_match("/^use function (.+?);/", $result->buffer, $use)) {
+        if (preg_match("/^use (?P<type>function |const )?(?P<name>.+?)( as (?P<alias>.+?))?;/", $result->buffer, $use)) {
             $result->buffer = substr($result->buffer, strlen($use[0]));
-            if (strpos($use[0], ' as ') !== false) {
-                list($function, $alias) = explode(' as ', $use[1]);
-            } else {
-                $function = $use[1];
-                $alias = substr($use[1], strrpos($use[1], '\\') + 1);
+
+            if (! isset($use['alias']) || strlen($use['alias']) == 0) {
+                $use['alias'] = substr($use['name'], strrpos($use['name'], '\\') + 1);
             }
-            $result->statements[] = sprintf("function %s() { return call_user_func_array('%s', func_get_args()); };", $alias, $function);
-            return true;
-        } else if (preg_match("/^use (.+?);/", $result->buffer, $use)) {
-            $result->buffer = substr($result->buffer, strlen($use[0]));
-            if (strpos($use[0], ' as ') !== false) {
-                list($class, $alias) = explode(' as ', $use[1]);
-            } else {
-                $class = $use[1];
-                $alias = substr($use[1], strrpos($use[1], '\\') + 1);
+
+            switch(trim($use['type'])) {
+                case 'function':
+                    $result->statements[] = sprintf("function %s() { return call_user_func_array('%s', func_get_args()); };", $use['alias'], $use['name']);
+                    break;
+                case 'const':
+                    $result->statements[] = sprintf("define('%s', %s);", $use['alias'], $use['name']);
+                    break;
+                default:
+                    $result->statements[] = sprintf("class_alias('%s', '%s');", $use['name'], $use['alias']);
+                    break;
             }
-            $result->statements[] = sprintf("class_alias('%s', '%s');", $class, $alias);
+
             return true;
         } else {
             return false;


### PR DESCRIPTION
This PR allow people using Boris to import function and constants using the new `use function`, `use const` syntax introduced with PHP 5.6.

I also used a named regexp to make things clearer.
