### PR TITLE
Adding '-a/--autoload' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+This is a fork of [borisrepl/boris](https://github.com/borisrepl/boris).
+This fork introduces the `--autoload` option (shothand `-a`) to Boris.
+This option makes Boris automatically detect if you are in a composer project and
+automatically load the classes of the project using the `autoload.php` script.
+
+<hr/>
+
 # Boris
 
 A tiny, but robust REPL for PHP.


### PR DESCRIPTION
This PR adds a `--autoload` (shorthand `-a`) option to boris. Adding this option will make Boris automatically search for a `autoload.php` file and require it so that the user's classes are available immediately.

#### Examples:

Using `-a` option, autoload.php is required automatically:
```bash
~/my_composer_project$ boris -a
Requiring autoload file: /Users/leonardoraele/my_composer_project/vendor/autoload.php
[1] boris> 
```

Not using `-a` option, boris works normally.
```bash
~/my_composer_project$ boris
[1] boris> 
```

Using `-a` option not in a composer project, nothing is loaded. Boris works normally.
```bash
~/my_composer_project$ cd ~
~$ boris -a
No autoload file found.
[1] boris> 
```